### PR TITLE
Add new option to exclude files from the sync set

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ activate :s3_sync do |s3_sync|
   s3_sync.version_bucket             = false
   s3_sync.index_document             = 'index.html'
   s3_sync.error_document             = '404.html'
+  s3_sync.exclude                    = [/^foo\/bar/]
 end
 ```
 
@@ -71,6 +72,7 @@ The following defaults apply to the configuration items:
 | encryption                 | ```false```                        |
 | acl                        | ```'public-read'```                |
 | version_bucket             | ```false```                        |
+| exclude                    | ```[]```                           |
 
 You do not need to specify the settings that match the defaults. This
 simplify the configuration of the extension:
@@ -313,6 +315,24 @@ settings. The ```index_document``` option tells which file name gets used as
 the index document of a directory (typically, ```index.html```), while
 ```error_document``` specifies the document to display for 4xx errors (ie,
 the 404 page).
+
+You can enable a custom [index document](http://docs.aws.amazon.com/AmazonS3/latest/dev/IndexDocumentSupport.html)
+and [error document](http://docs.aws.amazon.com/AmazonS3/latest/dev/CustomErrorDocSupport.html)
+settings. The ```index_document``` option tells which file name gets used as
+the index document of a directory (typically, ```index.html```), while
+```error_document``` specifies the document to display for 4xx errors (ie,
+the 404 page).
+
+#### Excluding files from the sync
+
+You can set the `exclude` option to an array of regexps that would be used to match agains all the
+resources (local and remote) to decide which files should be synced and which not. The remote path will be used
+when doing the match. For example, had we the following `exclude = [/^docs\//, /file.txt/]` then:
+
+- Local files under `docs/` (or prefixed with `docs/`) won't be uploaded to S3. Also any file that
+had `file.txt` on their remote path won't be uploaded either.
+- Remote files under `docs/` or with `file.txt` on their path won't be considered while doing the sync. This means
+that we could have a `docs/` dir on S3 and not locally and `s3_sync` won't remove the files remotelly.
 
 ## A Debt of Gratitude
 

--- a/lib/middleman-s3_sync/extension.rb
+++ b/lib/middleman-s3_sync/extension.rb
@@ -26,6 +26,7 @@ module Middleman
     option :index_document, nil, 'S3 custom index document path'
     option :error_document, nil, 'S3 custom error document path'
     option :content_types, {}, 'Custom content types'
+    option :exclude, [], "Regexps matching resources to exclude"
 
     def initialize(app, options_hash = {}, &block)
       super

--- a/lib/middleman/s3_sync/options.rb
+++ b/lib/middleman/s3_sync/options.rb
@@ -23,7 +23,8 @@ module Middleman
         :verbose,
         :content_types,
         :index_document,
-        :error_document
+        :error_document,
+        :exclude
       ]
       attr_accessor *OPTIONS
 

--- a/lib/middleman/s3_sync/resource.rb
+++ b/lib/middleman/s3_sync/resource.rb
@@ -119,7 +119,7 @@ module Middleman
       end
 
       def to_ignore?
-        status == :ignored || status == :alternate_encoding
+        status == :ignored || status == :excluded || status == :alternate_encoding
       end
 
       def local_content(&block)
@@ -134,7 +134,9 @@ module Middleman
                         :ignored
                       end
                     elsif local? && remote?
-                      if options.force
+                      if excluded?
+                        :excluded
+                      elsif options.force
                         :updated
                       elsif not caching_policy_match?
                         :updated
@@ -155,9 +157,15 @@ module Middleman
                         end
                       end
                     elsif local?
-                      :new
+                      if excluded?
+                        :excluded
+                      else
+                        :new
+                      end
                     elsif remote? && redirect?
                       :ignored
+                    elsif remote? && excluded?
+                      :excluded
                     elsif remote?
                       :deleted
                     else
@@ -167,6 +175,11 @@ module Middleman
 
       def local?
         File.exist?(local_path) && resource
+      end
+
+      def excluded?
+        excludes = options.exclude || []
+        excludes.find {|exclude| remote_path =~ exclude }
       end
 
       def remote?

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -17,6 +17,106 @@ describe Middleman::S3Sync::Resource do
     options.prefer_gzip = false
   end
 
+  context "a local and remote resource" do
+    let(:remote) {
+      double(
+        key: 'path/to/resource.html',
+        metadata: {}
+      )
+    }
+
+    context "without a prefix" do
+      subject(:resource) { Middleman::S3Sync::Resource.new(mm_resource, remote) }
+
+      before do
+        allow(File).to receive(:exist?).with('build/path/to/resource.html').and_return(true)
+      end
+
+      it "does have a remote equivalent" do
+        expect(resource).to be_remote
+      end
+
+      it "exists locally" do
+        expect(resource).to be_local
+      end
+
+      its(:path) { should eq 'path/to/resource.html'}
+      its(:local_path) { should eq 'build/path/to/resource.html' }
+      its(:remote_path) { should eq 'path/to/resource.html' }
+
+      context "file excluded" do
+        before do
+          options.exclude = [/^path/]
+        end
+
+        its(:status) { should eq :excluded }
+      end
+    end
+
+    context "with a prefix set" do
+      subject(:resource) { Middleman::S3Sync::Resource.new(mm_resource, remote) }
+      let(:remote) {
+        double(
+          key: 'bob/path/to/resource.html',
+          metadata: {}
+        )
+      }
+
+      before do
+        allow(File).to receive(:exist?).with('build/path/to/resource.html').and_return(true)
+        options.prefix = "bob" # not really needed
+      end
+
+      it "does have a remote equivalent" do
+        expect(resource).to be_remote
+      end
+
+      it "exists locally" do
+        expect(resource).to be_local
+      end
+
+      its(:path) { should eq 'path/to/resource.html' }
+      its(:local_path) { should eq 'build/path/to/resource.html' }
+      its(:remote_path) { should eq 'bob/path/to/resource.html' }
+
+      context "file excluded" do
+        before do
+          options.exclude = [/^bob\/path/]
+        end
+
+        its(:status) { should eq :excluded }
+      end
+    end
+
+    context "gzipped" do
+      subject(:resource) { Middleman::S3Sync::Resource.new(mm_resource, remote) }
+      before do
+        allow(File).to receive(:exist?).with('build/path/to/resource.html.gz').and_return(true)
+        options.prefer_gzip = true
+      end
+
+      it "does have a remote equivalent" do
+        expect(resource).to be_remote
+      end
+
+      it "exists locally" do
+        expect(resource).to be_local
+      end
+
+      its(:path) { should eq 'path/to/resource.html' }
+      its(:local_path) { should eq 'build/path/to/resource.html.gz' }
+      its(:remote_path) { should eq 'path/to/resource.html' }
+
+      context "file excluded" do
+        before do
+          options.exclude = [/^path/]
+        end
+
+        its(:status) { should eq :excluded }
+      end
+    end
+  end
+
   context "a new resource" do
     subject(:resource) { Middleman::S3Sync::Resource.new(mm_resource, nil) }
 
@@ -38,6 +138,14 @@ describe Middleman::S3Sync::Resource do
       its(:path) { should eq 'path/to/resource.html'}
       its(:local_path) { should eq 'build/path/to/resource.html' }
       its(:remote_path) { should eq 'path/to/resource.html' }
+
+      context "file excluded" do
+        before do
+          options.exclude = [/^path/]
+        end
+
+        its(:status) { should eq :excluded }
+      end
     end
 
     context "with a prefix set" do
@@ -57,6 +165,14 @@ describe Middleman::S3Sync::Resource do
       its(:path) { should eq 'path/to/resource.html' }
       its(:local_path) { should eq 'build/path/to/resource.html' }
       its(:remote_path) { should eq 'bob/path/to/resource.html' }
+
+      context "file excluded" do
+        before do
+          options.exclude = [/^bob\/path/]
+        end
+
+        its(:status) { should eq :excluded }
+      end
     end
 
     context "gzipped" do
@@ -76,6 +192,14 @@ describe Middleman::S3Sync::Resource do
       its(:path) { should eq 'path/to/resource.html' }
       its(:local_path) { should eq 'build/path/to/resource.html.gz' }
       its(:remote_path) { should eq 'path/to/resource.html' }
+
+      context "file excluded" do
+        before do
+          options.exclude = [/^path/]
+        end
+
+        its(:status) { should eq :excluded }
+      end
     end
   end
 
@@ -110,9 +234,21 @@ describe Middleman::S3Sync::Resource do
       its(:path) { should eq 'path/to/resource.html'}
       its(:local_path) { should eq 'build/path/to/resource.html' }
       its(:remote_path) { should eq 'path/to/resource.html' }
+
+      context "file excluded" do
+        subject(:resource) { Middleman::S3Sync::Resource.new(nil, remote) }
+
+        before do
+          options.exclude = [/^path/]
+        end
+
+        its(:status) { should eq :excluded }
+      end
     end
 
     context "with a prefix set" do
+      subject(:resource) { Middleman::S3Sync::Resource.new(nil, remote) }
+
       before do
         allow(File).to receive(:exist?).with('build/path/to/resource.html').and_return(false)
         allow(remote).to receive(:key).and_return('bob/path/to/resource.html')
@@ -131,6 +267,16 @@ describe Middleman::S3Sync::Resource do
       its(:path) { should eq 'path/to/resource.html' }
       its(:local_path) { should eq 'build/path/to/resource.html' }
       its(:remote_path) { should eq 'bob/path/to/resource.html' }
+
+      its(:status) { should eq :deleted }
+
+      context "file excluded" do
+        before do
+          options.exclude = [/^bob\/path/]
+        end
+
+        its(:status) { should eq :excluded }
+      end
     end
 
     context "gzipped" do
@@ -152,6 +298,14 @@ describe Middleman::S3Sync::Resource do
       its(:path) { should eq 'path/to/resource.html' }
       its(:local_path) { should eq 'build/path/to/resource.html' }
       its(:remote_path) { should eq 'path/to/resource.html' }
+
+      context "file excluded" do
+        before do
+          options.exclude = [/^path/]
+        end
+
+        its(:status) { should eq :excluded }
+      end
     end
   end
 end


### PR DESCRIPTION
### Why this change

Because we need a way to exclude files from the the sync set when using the `s3_sync` command in the `marketing-website` repo.

#### Related prs

- Configure the `middleman-s3_sync` gem on the marketing website to ignore a given set of dirs https://github.com/contentful/marketing-website/pull/727/files